### PR TITLE
Token verification cache should never fail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ This document describes changes between each past release.
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Make sure that caching of token verification nevers prevents from authenticating
+  requests (see Mozilla/PyFxA#48)
 
 
 2.3.0 (2016-12-22)

--- a/kinto_fxa/authentication.py
+++ b/kinto_fxa/authentication.py
@@ -25,13 +25,23 @@ class TokenVerificationCache(object):
         self.ttl = ttl
 
     def get(self, key):
-        return self.cache.get(key)
+        try:
+            return self.cache.get(key)
+        except:
+            logger.exception("Error while fetching from cache")
+        return None
 
     def set(self, key, value):
-        self.cache.set(key, value, self.ttl)
+        try:
+            self.cache.set(key, value, self.ttl)
+        except:
+            logger.exception("Error while storing in cache")
 
     def delete(self, key):
-        self.cache.delete(key)
+        try:
+            self.cache.delete(key)
+        except:
+            logger.exception("Error while deleting from cache")
 
 
 @implementer(IAuthenticationPolicy)

--- a/kinto_fxa/tests/test_authentication.py
+++ b/kinto_fxa/tests/test_authentication.py
@@ -35,6 +35,24 @@ class TokenVerificationCacheTest(unittest.TestCase):
         retrieved = self.cache.get('foobar')
         self.assertIsNone(retrieved)
 
+    def test_get_ignores_any_error(self):
+        with mock.patch.object(self.cache.cache, 'get', side_effect=ValueError):
+            retrieved = self.cache.get('foobar')
+        self.assertIsNone(retrieved)
+
+    def test_delete_ignores_any_error(self):
+        self.cache.set('foobar', 'toto')
+        with mock.patch.object(self.cache.cache, 'delete', side_effect=ValueError):
+            self.cache.delete('foobar')
+        retrieved = self.cache.get('foobar')
+        self.assertIsNotNone(retrieved)
+
+    def test_set_ignores_any_error(self):
+        with mock.patch.object(self.cache.cache, 'set', side_effect=ValueError):
+            self.cache.set('foobar', 'toto')
+        retrieved = self.cache.get('foobar')
+        self.assertIsNone(retrieved)
+
 
 class FxAOAuthAuthenticationPolicyTest(unittest.TestCase):
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27,py34,py35,flake8
+skip_missing_interpreters = True
 
 [testenv]
 commands =
@@ -17,3 +18,6 @@ install_command = pip install --process-dependency-links --pre {opts} {packages}
 commands = flake8 kinto_fxa
 deps =
     flake8
+
+[flake8]
+max-line-length = 99


### PR DESCRIPTION
Mozilla/PyFxA#48